### PR TITLE
Implementing board class

### DIFF
--- a/src/game/board.py
+++ b/src/game/board.py
@@ -20,7 +20,7 @@ class Board:
     def __init__(self):
         self.board = [[EMPTY] * COLS for _ in range(ROWS)]
 
-    def copy(self):
+    def copy(self) -> Board:
         """Return a deep copy of the board."""
         new_board = Board()
         new_board.board = [row[:] for row in self.board]
@@ -38,6 +38,9 @@ class Board:
         Drop player's disc into column col.
         Returns True on success, False if the column is full.
         """
+        if player not in (PLAYER1, PLAYER2):
+            raise ValueError("player must be PLAYER1 or PLAYER2")
+
         if not self.can_drop(col):
             return False
         # Find the lowest empty row in the column
@@ -71,7 +74,7 @@ class Board:
     # ------------------------------------------------------------------
     # Win / draw detection
     # ------------------------------------------------------------------
-    def _check_line(self, cells) -> int:
+    def _check_line(self, cells: list[int]) -> int:
         """
         Given a list of cell values, return the player who has 4 in a row,
         or 0 if neither does.
@@ -131,7 +134,7 @@ class Board:
     # ------------------------------------------------------------------
     # Possible moves
     # ------------------------------------------------------------------
-    def get_possible_moves(self, player: int):
+    def get_possible_moves(self, player: int) -> list[tuple[str, int]]:
         """
         Return a list of (move_type, col) tuples for the given player.
         move_type is 'drop' or 'pop'.

--- a/src/game/board.py
+++ b/src/game/board.py
@@ -20,7 +20,7 @@ class Board:
     def __init__(self):
         self.board = [[EMPTY] * COLS for _ in range(ROWS)]
 
-    def copy(self) -> Board:
+    def copy(self) -> "Board":
         """Return a deep copy of the board."""
         new_board = Board()
         new_board.board = [row[:] for row in self.board]

--- a/src/game/board.py
+++ b/src/game/board.py
@@ -11,7 +11,7 @@ COLS = 7
 EMPTY = 0
 PLAYER1 = 1
 PLAYER2 = 2
-SYMBOLS = {EMPTY: '-', PLAYER1: 'X', PLAYER2: 'O'}
+SYMBOLS = {EMPTY: "-", PLAYER1: "X", PLAYER2: "O"}
 
 
 class Board:
@@ -110,18 +110,14 @@ class Board:
         # Diagonal (top-left to bottom-right)
         for row in range(ROWS - 3):
             for col in range(COLS - 3):
-                w = self._check_line(
-                    [self.board[row + k][col + k] for k in range(4)]
-                )
+                w = self._check_line([self.board[row + k][col + k] for k in range(4)])
                 if w:
                     return w
 
         # Diagonal (top-right to bottom-left)
         for row in range(ROWS - 3):
             for col in range(3, COLS):
-                w = self._check_line(
-                    [self.board[row + k][col - k] for k in range(4)]
-                )
+                w = self._check_line([self.board[row + k][col - k] for k in range(4)])
                 if w:
                     return w
 
@@ -142,10 +138,10 @@ class Board:
         moves = []
         for col in range(COLS):
             if self.can_drop(col):
-                moves.append(('drop', col))
+                moves.append(("drop", col))
         for col in range(COLS):
             if self.can_pop(col, player):
-                moves.append(('pop', col))
+                moves.append(("pop", col))
         return moves
 
     # ------------------------------------------------------------------
@@ -166,5 +162,5 @@ class Board:
         """Return the string representation of the board"""
         lines = []
         for row in self.board:
-            lines.append(''.join(SYMBOLS[cell] for cell in row))
-        return '\n'.join(lines)
+            lines.append("".join(SYMBOLS[cell] for cell in row))
+        return "\n".join(lines)

--- a/src/game/board.py
+++ b/src/game/board.py
@@ -18,31 +18,41 @@ class Board:
     """Represents a PopOut game board."""
 
     def __init__(self):
-        raise NotImplementedError("Board logic is not implemented yet.")
-    
+        self.board = [[EMPTY] * COLS for _ in range(ROWS)]
+
     def copy(self):
-        raise NotImplementedError("Board logic is not implemented yet.")
+        """Return a deep copy of the board."""
+        new_board = Board()
+        new_board.board = [row[:] for row in self.board]
+        return new_board
 
     # ------------------------------------------------------------------
     # Drop move: place a disc in column col from the top
     # ------------------------------------------------------------------
     def can_drop(self, col: int) -> bool:
         """Return True if column col has at least one empty cell."""
-        raise NotImplementedError("Board logic is not implemented yet.")
+        return 0 <= col < COLS and self.board[0][col] == EMPTY
 
     def drop(self, col: int, player: int) -> bool:
         """
         Drop player's disc into column col.
         Returns True on success, False if the column is full.
         """
-        raise NotImplementedError("Board logic is not implemented yet.")
+        if not self.can_drop(col):
+            return False
+        # Find the lowest empty row in the column
+        for row in range(ROWS - 1, -1, -1):
+            if self.board[row][col] == EMPTY:
+                self.board[row][col] = player
+                return True
+        return False
 
     # ------------------------------------------------------------------
     # Pop move: remove a disc from the bottom of a column
     # ------------------------------------------------------------------
     def can_pop(self, col: int, player: int) -> bool:
         """Return True if column col's bottom cell contains player's disc."""
-        raise NotImplementedError("Board logic is not implemented yet.")
+        return 0 <= col < COLS and self.board[ROWS - 1][col] == player
 
     def pop(self, col: int, player: int) -> bool:
         """
@@ -50,7 +60,13 @@ class Board:
         Every disc above it shifts down by one row.
         Returns True on success, False otherwise.
         """
-        raise NotImplementedError("Board logic is not implemented yet.")
+        if not self.can_pop(col, player):
+            return False
+        # Shift all discs down (remove bottom, shift rest down)
+        for row in range(ROWS - 1, 0, -1):
+            self.board[row][col] = self.board[row - 1][col]
+        self.board[0][col] = EMPTY
+        return True
 
     # ------------------------------------------------------------------
     # Win / draw detection
@@ -60,19 +76,58 @@ class Board:
         Given a list of cell values, return the player who has 4 in a row,
         or 0 if neither does.
         """
-        raise NotImplementedError("Board logic is not implemented yet.")
+        for player in (PLAYER1, PLAYER2):
+            count = 0
+            for cell in cells:
+                if cell == player:
+                    count += 1
+                    if count >= 4:
+                        return player
+                else:
+                    count = 0
+        return 0
 
     def get_winner(self) -> int:
         """
         Return PLAYER1, PLAYER2, or 0 (no winner yet).
         Checks all horizontal, vertical, and diagonal lines.
         """
-        raise NotImplementedError("Board logic is not implemented yet.")
+        # Horizontal
+        for row in range(ROWS):
+            w = self._check_line(self.board[row])
+            if w:
+                return w
+
+        # Vertical
+        for col in range(COLS):
+            w = self._check_line([self.board[row][col] for row in range(ROWS)])
+            if w:
+                return w
+
+        # Diagonal (top-left to bottom-right)
+        for row in range(ROWS - 3):
+            for col in range(COLS - 3):
+                w = self._check_line(
+                    [self.board[row + k][col + k] for k in range(4)]
+                )
+                if w:
+                    return w
+
+        # Diagonal (top-right to bottom-left)
+        for row in range(ROWS - 3):
+            for col in range(3, COLS):
+                w = self._check_line(
+                    [self.board[row + k][col - k] for k in range(4)]
+                )
+                if w:
+                    return w
+
+        return 0
 
     def is_full(self) -> bool:
         """Return True if every cell on the board is occupied."""
-        raise NotImplementedError("Board logic is not implemented yet.")
-    
+        return all(self.board[0][col] != EMPTY for col in range(COLS))
+
     # ------------------------------------------------------------------
     # Possible moves
     # ------------------------------------------------------------------
@@ -81,22 +136,31 @@ class Board:
         Return a list of (move_type, col) tuples for the given player.
         move_type is 'drop' or 'pop'.
         """
-        raise NotImplementedError("Board logic is not implemented yet.")
+        moves = []
+        for col in range(COLS):
+            if self.can_drop(col):
+                moves.append(('drop', col))
+        for col in range(COLS):
+            if self.can_pop(col, player):
+                moves.append(('pop', col))
+        return moves
 
     # ------------------------------------------------------------------
     # Board state encoding (for repetition detection / dataset)
     # ------------------------------------------------------------------
     def to_tuple(self):
         """Return an immutable representation of the board state."""
-        raise NotImplementedError("Board logic is not implemented yet.")
+        return tuple(tuple(row) for row in self.board)
 
     def to_flat_list(self):
         """Return a flat list of cell values (row-major order)."""
-        raise NotImplementedError("Board logic is not implemented yet.")
+        return [cell for row in self.board for cell in row]
 
     # ------------------------------------------------------------------
     # Display
     # ------------------------------------------------------------------
     def __str__(self) -> str:
-        """Return the string representation of the board"""
-        raise NotImplementedError("Board logic is not implemented yet.")
+        lines = []
+        for row in self.board:
+            lines.append(''.join(SYMBOLS[cell] for cell in row))
+        return '\n'.join(lines)

--- a/src/game/board.py
+++ b/src/game/board.py
@@ -160,6 +160,7 @@ class Board:
     # Display
     # ------------------------------------------------------------------
     def __str__(self) -> str:
+        """Return the string representation of the board"""
         lines = []
         for row in self.board:
             lines.append(''.join(SYMBOLS[cell] for cell in row))

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -136,6 +136,25 @@ class TestDropMove:
 
         assert result is False
 
+    def test_drop_invalid_player_raises_value_error(self):
+        """Test drop raises ValueError for invalid player value."""
+        board = Board()
+
+        with pytest.raises(ValueError, match="player must be PLAYER1 or PLAYER2"):
+            board.drop(0, 99)
+
+    def test_drop_returns_false_if_no_empty_cell_found(self, monkeypatch):
+        """Test defensive return False when no empty cell exists in scan."""
+        board = Board()
+        col = 0
+
+        # Force can_drop to pass while column has no EMPTY values.
+        monkeypatch.setattr(board, "can_drop", lambda _: True)
+        for row in range(ROWS):
+            board.board[row][col] = PLAYER1
+
+        assert board.drop(col, PLAYER1) is False
+
 class TestPopMove:
     """Tests for pop and can_pop methods."""
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -48,10 +48,10 @@ class TestBoardCopy:
         board1 = Board()
         board1.drop(0, PLAYER1)
         board2 = board1.copy()
-        
+
         # Modify board2
         board2.drop(1, PLAYER2)
-        
+
         # board1 should be unchanged
         assert board1.board[ROWS - 1][0] == PLAYER1
         assert board1.board[ROWS - 1][1] == EMPTY
@@ -62,9 +62,9 @@ class TestBoardCopy:
         board1.drop(0, PLAYER1)
         board1.drop(0, PLAYER2)
         board1.drop(1, PLAYER1)
-        
+
         board2 = board1.copy()
-        
+
         assert board2.board == board1.board
         assert board2 is not board1  # Should be different objects
 
@@ -90,7 +90,7 @@ class TestDropMove:
         board = Board()
         board.drop(0, PLAYER1)
         board.drop(0, PLAYER2)
-        
+
         assert board.board[ROWS - 1][0] == PLAYER1
         assert board.board[ROWS - 2][0] == PLAYER2
 
@@ -108,7 +108,7 @@ class TestDropMove:
         # Fill column 0
         for i in range(ROWS):
             board.drop(0, PLAYER1)
-        
+
         assert board.can_drop(0) is False
 
     def test_drop_full_column_returns_false(self):
@@ -117,7 +117,7 @@ class TestDropMove:
         # Fill column 0
         for i in range(ROWS):
             board.drop(0, PLAYER1)
-        
+
         assert board.drop(0, PLAYER2) is False
 
     def test_drop_multiple_columns(self):
@@ -125,7 +125,7 @@ class TestDropMove:
         board = Board()
         for col in range(COLS):
             board.drop(col, PLAYER1)
-        
+
         for col in range(COLS):
             assert board.board[ROWS - 1][col] == PLAYER1
 
@@ -154,6 +154,7 @@ class TestDropMove:
             board.board[row][col] = PLAYER1
 
         assert board.drop(col, PLAYER1) is False
+
 
 class TestPopMove:
     """Tests for pop and can_pop methods."""
@@ -188,9 +189,9 @@ class TestPopMove:
         assert board.drop(0, PLAYER1) is True
         assert board.drop(0, PLAYER2) is True
         assert board.drop(0, PLAYER1) is True
-        
+
         assert board.pop(0, PLAYER1) is True
-        
+
         # After popping bottom PLAYER1, PLAYER2 should be at bottom
         assert board.board[ROWS - 1][0] == PLAYER2
         assert board.board[ROWS - 2][0] == PLAYER1
@@ -215,7 +216,7 @@ class TestPopMove:
         board.drop(0, PLAYER1)
         board.drop(0, PLAYER2)
         board.drop(0, PLAYER1)
-        
+
         assert board.pop(0, PLAYER1) is True
         assert board.pop(0, PLAYER2) is True
         assert board.pop(0, PLAYER1) is True
@@ -255,7 +256,7 @@ class TestWinDetection:
         # Create a horizontal line of Player1 pieces
         for col in range(4):
             board.drop(col, PLAYER1)
-        
+
         assert board.get_winner() == PLAYER1
 
     def test_vertical_win(self):
@@ -264,7 +265,7 @@ class TestWinDetection:
         # Stack 4 pieces in same column
         for _ in range(4):
             board.drop(0, PLAYER1)
-        
+
         assert board.get_winner() == PLAYER1
 
     def test_diagonal_win_ascending(self):
@@ -278,19 +279,19 @@ class TestWinDetection:
         #   - - X O O - -
         #   - X O O O - -
         board.drop(1, PLAYER1)
-        
+
         board.drop(2, PLAYER2)
-        board.drop(2, PLAYER1) 
-        
+        board.drop(2, PLAYER1)
+
         board.drop(3, PLAYER2)
         board.drop(3, PLAYER2)
-        board.drop(3, PLAYER1) 
-        
+        board.drop(3, PLAYER1)
+
         board.drop(4, PLAYER2)
         board.drop(4, PLAYER2)
         board.drop(4, PLAYER2)
-        board.drop(4, PLAYER1) 
-        
+        board.drop(4, PLAYER1)
+
         assert board.get_winner() == PLAYER1
 
     def test_diagonal_win_descending(self):
@@ -308,16 +309,16 @@ class TestWinDetection:
         board.drop(2, PLAYER2)
         board.drop(2, PLAYER1)
         board.drop(2, PLAYER1)
-        
+
         board.drop(3, PLAYER2)
         board.drop(3, PLAYER2)
-        board.drop(3, PLAYER1) 
+        board.drop(3, PLAYER1)
 
         board.drop(4, PLAYER2)
-        board.drop(4, PLAYER1) 
-        
+        board.drop(4, PLAYER1)
+
         board.drop(5, PLAYER1)
-        
+
         assert board.get_winner() == PLAYER1
 
     def test_no_winner_empty_board(self):
@@ -376,9 +377,9 @@ class TestPossibleMoves:
         """Test possible moves on empty board."""
         board = Board()
         moves = board.get_possible_moves(PLAYER1)
-        
+
         # All columns should allow drop moves
-        drop_moves = [move for move in moves if move[0] == 'drop']
+        drop_moves = [move for move in moves if move[0] == "drop"]
         assert len(drop_moves) >= COLS
 
     def test_possible_moves_include_drops(self):
@@ -386,27 +387,27 @@ class TestPossibleMoves:
         board = Board()
         board.drop(0, PLAYER1)
         moves = board.get_possible_moves(PLAYER1)
-        
+
         # Should have drop option for column 0 (not full yet)
-        assert any(move[0] == 'drop' and move[1] == 0 for move in moves)
+        assert any(move[0] == "drop" and move[1] == 0 for move in moves)
 
     def test_possible_moves_include_pops(self):
         """Test that possible moves include pop moves when applicable."""
         board = Board()
         board.drop(0, PLAYER1)
         moves = board.get_possible_moves(PLAYER1)
-        
+
         # Should have pop option for column 0
-        assert any(move[0] == 'pop' and move[1] == 0 for move in moves)
+        assert any(move[0] == "pop" and move[1] == 0 for move in moves)
 
     def test_possible_moves_no_pop_for_other_player(self):
         """Test no pop move if bottom piece belongs to other player."""
         board = Board()
         board.drop(0, PLAYER2)
         moves = board.get_possible_moves(PLAYER1)
-        
+
         # Should not have pop option for column 0
-        pop_moves = [move for move in moves if move[0] == 'pop' and move[1] == 0]
+        pop_moves = [move for move in moves if move[0] == "pop" and move[1] == 0]
         assert len(pop_moves) == 0
 
     def test_possible_moves_full_column_no_drop(self):
@@ -415,21 +416,21 @@ class TestPossibleMoves:
         # Fill column 0
         for _ in range(ROWS):
             board.drop(0, PLAYER1)
-        
+
         moves = board.get_possible_moves(PLAYER1)
-        drop_moves = [move for move in moves if move[0] == 'drop' and move[1] == 0]
+        drop_moves = [move for move in moves if move[0] == "drop" and move[1] == 0]
         assert len(drop_moves) == 0
 
     def test_possible_moves_returns_tuples(self):
         """Test that get_possible_moves returns list of tuples."""
         board = Board()
         moves = board.get_possible_moves(PLAYER1)
-        
+
         assert isinstance(moves, list)
         for move in moves:
             assert isinstance(move, tuple)
             assert len(move) == 2
-            assert move[0] in ['drop', 'pop']
+            assert move[0] in ["drop", "pop"]
             assert isinstance(move[1], int)
 
 
@@ -441,7 +442,7 @@ class TestBoardStateEncoding:
         board = Board()
         board.drop(0, PLAYER1)
         board_tuple = board.to_tuple()
-        
+
         # Should be immutable (tuple)
         assert isinstance(board_tuple, tuple)
 
@@ -450,35 +451,35 @@ class TestBoardStateEncoding:
         board1 = Board()
         board1.drop(0, PLAYER1)
         board1.drop(1, PLAYER2)
-        
+
         board2 = Board()
         board2.drop(0, PLAYER1)
         board2.drop(1, PLAYER2)
-        
+
         assert board1.to_tuple() == board2.to_tuple()
 
     def test_to_tuple_different_states(self):
         """Test that different states produce different tuples."""
         board1 = Board()
         board1.drop(0, PLAYER1)
-        
+
         board2 = Board()
         board2.drop(0, PLAYER2)
-        
+
         assert board1.to_tuple() != board2.to_tuple()
 
     def test_to_flat_list_length(self):
         """Test that to_flat_list has correct length."""
         board = Board()
         flat = board.to_flat_list()
-        
+
         assert len(flat) == ROWS * COLS
 
     def test_to_flat_list_empty_board(self):
         """Test to_flat_list for empty board."""
         board = Board()
         flat = board.to_flat_list()
-        
+
         assert all(cell == EMPTY for cell in flat)
 
     def test_to_flat_list_represents_state(self):
@@ -486,9 +487,9 @@ class TestBoardStateEncoding:
         board = Board()
         board.drop(0, PLAYER1)
         board.drop(1, PLAYER2)
-        
+
         flat = board.to_flat_list()
-        
+
         # Bottom row should have pieces in columns 0 and 1
         bottom_row_flat = flat[-COLS:]
         assert bottom_row_flat[0] == PLAYER1
@@ -498,9 +499,9 @@ class TestBoardStateEncoding:
         """Test that to_flat_list uses row-major order."""
         board = Board()
         board.drop(0, PLAYER1)
-        
+
         flat = board.to_flat_list()
-        
+
         # Last element of flat list should be bottom-right cell
         assert flat[-1] == EMPTY  # Bottom right is empty
 
@@ -518,30 +519,30 @@ class TestBoardDisplay:
         """Test string representation of empty board."""
         board = Board()
         board_str = str(board)
-        
+
         # Should contain representation of empty cells
-        assert '-' in board_str
+        assert "-" in board_str
 
     def test_str_with_pieces(self):
         """Test string representation with pieces."""
         board = Board()
         board.drop(0, PLAYER1)
         board.drop(1, PLAYER2)
-        
+
         board_str = str(board)
-        
+
         # Should contain both piece representations
-        assert 'X' in board_str
-        assert 'O' in board_str
+        assert "X" in board_str
+        assert "O" in board_str
 
     def test_str_multiple_lines(self):
         """Test that string representation has multiple lines."""
         board = Board()
         board.drop(0, PLAYER1)
-        
+
         board_str = str(board)
-        lines = board_str.strip().split('\n')
-        
+        lines = board_str.strip().split("\n")
+
         # Should have ROWS lines
         assert len(lines) == ROWS
 
@@ -549,8 +550,8 @@ class TestBoardDisplay:
         """Test that each line has correct width."""
         board = Board()
         board_str = str(board)
-        lines = board_str.strip().split('\n')
-        
+        lines = board_str.strip().split("\n")
+
         # Each line should represent COLS columns
         for line in lines:
             # Account for spacing/separators

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -12,13 +12,11 @@ from src.game.board import Board, ROWS, COLS, EMPTY, PLAYER1, PLAYER2
 class TestBoardInitialization:
     """Tests for Board initialization."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_init_creates_board(self):
         """Test that __init__ creates a valid board."""
         board = Board()
         assert board is not None
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_init_board_all_empty(self):
         """Test that initialized board has all empty cells."""
         board = Board()
@@ -27,7 +25,6 @@ class TestBoardInitialization:
             for cell in row:
                 assert cell == EMPTY
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_init_board_dimensions(self):
         """Test that board has correct dimensions."""
         board = Board()
@@ -38,7 +35,6 @@ class TestBoardInitialization:
 
 class TestBoardCopy:
     """Tests for Board.copy() method."""
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_copy_creates_independent_board(self):
         """Test that copy creates an independent board instance."""
         board1 = Board()
@@ -52,7 +48,6 @@ class TestBoardCopy:
         assert board1.board[ROWS - 1][0] == PLAYER1
         assert board1.board[ROWS - 1][1] == EMPTY
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_copy_preserves_state(self):
         """Test that copy preserves the current board state."""
         board1 = Board()
@@ -69,14 +64,12 @@ class TestBoardCopy:
 class TestDropMove:
     """Tests for drop and can_drop methods."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_can_drop_empty_column(self):
         """Test can_drop returns True for empty column."""
         board = Board()
         assert board.can_drop(0) is True
         assert board.can_drop(COLS - 1) is True
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_single_piece(self):
         """Test dropping a single piece into empty column."""
         board = Board()
@@ -84,7 +77,6 @@ class TestDropMove:
         assert result is True
         assert board.board[ROWS - 1][0] == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_stacks_pieces(self):
         """Test that pieces stack on top of each other."""
         board = Board()
@@ -94,7 +86,6 @@ class TestDropMove:
         assert board.board[ROWS - 1][0] == PLAYER1
         assert board.board[ROWS - 2][0] == PLAYER2
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_fills_column(self):
         """Test dropping pieces until column is full."""
         board = Board()
@@ -103,7 +94,6 @@ class TestDropMove:
             result = board.drop(0, PLAYER1 if i % 2 == 0 else PLAYER2)
             assert result is True
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_can_drop_full_column_returns_false(self):
         """Test can_drop returns False for full column."""
         board = Board()
@@ -113,7 +103,6 @@ class TestDropMove:
         
         assert board.can_drop(0) is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_full_column_returns_false(self):
         """Test drop returns False when column is full."""
         board = Board()
@@ -123,7 +112,6 @@ class TestDropMove:
         
         assert board.drop(0, PLAYER2) is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_multiple_columns(self):
         """Test dropping pieces into multiple columns."""
         board = Board()
@@ -133,7 +121,6 @@ class TestDropMove:
         for col in range(COLS):
             assert board.board[ROWS - 1][col] == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_drop_invalid_column_index(self):
         """Test drop with invalid column index."""
         board = Board()
@@ -144,27 +131,23 @@ class TestDropMove:
 class TestPopMove:
     """Tests for pop and can_pop methods."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_can_pop_empty_column_returns_false(self):
         """Test can_pop returns False for empty column."""
         board = Board()
         assert board.can_pop(0, PLAYER1) is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_can_pop_wrong_player_returns_false(self):
         """Test can_pop returns False if bottom piece doesn't belong to player."""
         board = Board()
         board.drop(0, PLAYER1)
         assert board.can_pop(0, PLAYER2) is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_can_pop_correct_player_returns_true(self):
         """Test can_pop returns True for correct player."""
         board = Board()
         board.drop(0, PLAYER1)
         assert board.can_pop(0, PLAYER1) is True
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_pop_removes_bottom_piece(self):
         """Test that pop removes the bottom piece."""
         board = Board()
@@ -172,7 +155,6 @@ class TestPopMove:
         assert board.pop(0, PLAYER1) is True
         assert board.board[ROWS - 1][0] == EMPTY
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_pop_shifts_pieces_down(self):
         """Test that pop shifts pieces down."""
         board = Board()
@@ -187,7 +169,6 @@ class TestPopMove:
         assert board.board[ROWS - 2][0] == PLAYER1
         assert board.board[ROWS - 3][0] == EMPTY
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_pop_wrong_player_returns_false(self):
         """Test pop returns False with wrong player."""
         board = Board()
@@ -195,14 +176,12 @@ class TestPopMove:
         assert board.pop(0, PLAYER2) is False
         assert board.board[ROWS - 1][0] == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_pop_empty_column_returns_false(self):
         """Test pop returns False on empty column."""
         board = Board()
         result = board.pop(0, PLAYER1)
         assert result is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_pop_multiple_pieces_sequence(self):
         """Test popping multiple pieces in sequence."""
         board = Board()
@@ -219,35 +198,30 @@ class TestPopMove:
 class TestWinDetection:
     """Tests for get_winner and _check_line methods."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_check_line_four_in_row(self):
         """Test _check_line detects four in a row."""
         board = Board()
         line = [PLAYER1, PLAYER1, PLAYER1, PLAYER1, EMPTY, EMPTY, EMPTY]
         assert board._check_line(line) == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_check_line_player2_wins(self):
         """Test _check_line detects player 2 win."""
         board = Board()
         line = [EMPTY, PLAYER2, PLAYER2, PLAYER2, PLAYER2, EMPTY, EMPTY]
         assert board._check_line(line) == PLAYER2
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_check_line_no_winner(self):
         """Test _check_line returns 0 for no winner."""
         board = Board()
         line = [EMPTY, EMPTY, PLAYER1, PLAYER2, PLAYER1, PLAYER2, EMPTY]
         assert board._check_line(line) == 0
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_check_line_three_in_row(self):
         """Test _check_line doesn't count three in a row."""
         board = Board()
         line = [EMPTY, EMPTY, PLAYER1, PLAYER1, PLAYER1, PLAYER2, EMPTY]
         assert board._check_line(line) == 0
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_horizontal_win(self):
         """Test detecting horizontal win."""
         board = Board()
@@ -257,7 +231,6 @@ class TestWinDetection:
         
         assert board.get_winner() == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_vertical_win(self):
         """Test detecting vertical win."""
         board = Board()
@@ -267,7 +240,6 @@ class TestWinDetection:
         
         assert board.get_winner() == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_diagonal_win_ascending(self):
         """Test detecting diagonal win (ascending)."""
         board = Board()
@@ -294,7 +266,6 @@ class TestWinDetection:
         
         assert board.get_winner() == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_diagonal_win_descending(self):
         """Test detecting diagonal win (descending)."""
         board = Board()
@@ -322,13 +293,11 @@ class TestWinDetection:
         
         assert board.get_winner() == PLAYER1
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_no_winner_empty_board(self):
         """Test no winner on empty board."""
         board = Board()
         assert board.get_winner() == 0
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_no_winner_partial_board(self):
         """Test no winner with partial board."""
         board = Board()
@@ -341,13 +310,11 @@ class TestWinDetection:
 class TestBoardFull:
     """Tests for is_full method."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_empty_board_not_full(self):
         """Test empty board is not full."""
         board = Board()
         assert board.is_full() is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_partially_filled_board_not_full(self):
         """Test partially filled board is not full."""
         board = Board()
@@ -355,7 +322,6 @@ class TestBoardFull:
             board.drop(col, PLAYER1)
         assert board.is_full() is False
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_completely_filled_board_is_full(self):
         """Test completely filled board is full."""
         board = Board()
@@ -365,7 +331,6 @@ class TestBoardFull:
                 board.drop(col, PLAYER1)
         assert board.is_full() is True
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_full_board_alternates(self):
         """Test full board with alternating players."""
         board = Board()
@@ -380,7 +345,6 @@ class TestBoardFull:
 class TestPossibleMoves:
     """Tests for get_possible_moves method."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_empty_board(self):
         """Test possible moves on empty board."""
         board = Board()
@@ -390,7 +354,6 @@ class TestPossibleMoves:
         drop_moves = [move for move in moves if move[0] == 'drop']
         assert len(drop_moves) >= COLS
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_include_drops(self):
         """Test that possible moves include drop moves."""
         board = Board()
@@ -400,7 +363,6 @@ class TestPossibleMoves:
         # Should have drop option for column 0 (not full yet)
         assert any(move[0] == 'drop' and move[1] == 0 for move in moves)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_include_pops(self):
         """Test that possible moves include pop moves when applicable."""
         board = Board()
@@ -410,7 +372,6 @@ class TestPossibleMoves:
         # Should have pop option for column 0
         assert any(move[0] == 'pop' and move[1] == 0 for move in moves)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_no_pop_for_other_player(self):
         """Test no pop move if bottom piece belongs to other player."""
         board = Board()
@@ -421,7 +382,6 @@ class TestPossibleMoves:
         pop_moves = [move for move in moves if move[0] == 'pop' and move[1] == 0]
         assert len(pop_moves) == 0
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_full_column_no_drop(self):
         """Test no drop move for full column."""
         board = Board()
@@ -433,7 +393,6 @@ class TestPossibleMoves:
         drop_moves = [move for move in moves if move[0] == 'drop' and move[1] == 0]
         assert len(drop_moves) == 0
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_possible_moves_returns_tuples(self):
         """Test that get_possible_moves returns list of tuples."""
         board = Board()
@@ -450,7 +409,6 @@ class TestPossibleMoves:
 class TestBoardStateEncoding:
     """Tests for to_tuple and to_flat_list methods."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_tuple_immutable(self):
         """Test that to_tuple returns an immutable structure."""
         board = Board()
@@ -460,7 +418,6 @@ class TestBoardStateEncoding:
         # Should be immutable (tuple)
         assert isinstance(board_tuple, tuple)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_tuple_represents_state(self):
         """Test that to_tuple represents board state."""
         board1 = Board()
@@ -473,7 +430,6 @@ class TestBoardStateEncoding:
         
         assert board1.to_tuple() == board2.to_tuple()
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_tuple_different_states(self):
         """Test that different states produce different tuples."""
         board1 = Board()
@@ -484,7 +440,6 @@ class TestBoardStateEncoding:
         
         assert board1.to_tuple() != board2.to_tuple()
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_flat_list_length(self):
         """Test that to_flat_list has correct length."""
         board = Board()
@@ -492,7 +447,6 @@ class TestBoardStateEncoding:
         
         assert len(flat) == ROWS * COLS
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_flat_list_empty_board(self):
         """Test to_flat_list for empty board."""
         board = Board()
@@ -500,7 +454,6 @@ class TestBoardStateEncoding:
         
         assert all(cell == EMPTY for cell in flat)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_flat_list_represents_state(self):
         """Test that to_flat_list represents board state."""
         board = Board()
@@ -514,7 +467,6 @@ class TestBoardStateEncoding:
         assert bottom_row_flat[0] == PLAYER1
         assert bottom_row_flat[1] == PLAYER2
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_to_flat_list_row_major_order(self):
         """Test that to_flat_list uses row-major order."""
         board = Board()
@@ -529,14 +481,12 @@ class TestBoardStateEncoding:
 class TestBoardDisplay:
     """Tests for __str__ method."""
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_str_returns_string(self):
         """Test that __str__ returns a string."""
         board = Board()
         result = board.__str__()
         assert isinstance(result, str)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_str_empty_board(self):
         """Test string representation of empty board."""
         board = Board()
@@ -545,7 +495,6 @@ class TestBoardDisplay:
         # Should contain representation of empty cells
         assert '-' in board_str
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_str_with_pieces(self):
         """Test string representation with pieces."""
         board = Board()
@@ -558,7 +507,6 @@ class TestBoardDisplay:
         assert 'X' in board_str
         assert 'O' in board_str
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_str_multiple_lines(self):
         """Test that string representation has multiple lines."""
         board = Board()
@@ -570,7 +518,6 @@ class TestBoardDisplay:
         # Should have ROWS lines
         assert len(lines) == ROWS
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_str_correct_width(self):
         """Test that each line has correct width."""
         board = Board()

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -35,6 +35,14 @@ class TestBoardInitialization:
 
 class TestBoardCopy:
     """Tests for Board.copy() method."""
+
+    def test_copy_returns_board_instance(self):
+        """Test that copy returns a Board instance."""
+        board = Board()
+        board_copy = board.copy()
+
+        assert isinstance(board_copy, Board)
+
     def test_copy_creates_independent_board(self):
         """Test that copy creates an independent board instance."""
         board1 = Board()


### PR DESCRIPTION
This pull request implements the complete game logic for the `Board` class in `src/game/board.py`, including initialization, moves, win detection, and board state representation. It also updates the test suite in `tests/test_board.py` by removing expected failures and enabling full testing of the board functionality.

Game logic implementation in `Board`:

* Added board initialization, deep copy functionality, and methods for dropping and popping discs, including validation checks for moves. (`src/game/board.py`)
* Implemented win detection logic (`get_winner` and `_check_line`), covering horizontal, vertical, and diagonal lines. (`src/game/board.py`)
* Added methods for checking if the board is full, generating possible moves, and encoding board state for comparison and display. (`src/game/board.py`)

Test suite updates:

* Removed `@pytest.mark.xfail` decorators from all board-related tests, enabling them to run and validate the new implementations. (`tests/test_board.py`)
* Cleaned up test cases to directly test board logic, including initialization, move validity, win detection, and board fullness. (`tests/test_board.py`).

Merging into main this closes #3.