### PR TITLE
Refactor HumanPlayer input handling to use shorthand commands and imp…

### DIFF
--- a/src/game/player.py
+++ b/src/game/player.py
@@ -76,30 +76,39 @@ class HumanPlayer(Player):
         while True:
 
             prompt = (
-                "Enter move type (drop/pop/draw): "
+                "Enter move (d<col>/p<col>/draw) [e.g., d3, p6]: "
                 if can_draw
-                else "Enter move type (drop/pop): "
+                else "Enter move (d<col>/p<col>) [e.g., d3, p6]: "
             )
-            move_type = input(prompt).strip().lower()
+            command = input(prompt).strip().lower()
 
-            if move_type == "draw":
+            if command == "draw":
                 if can_draw:
                     return ("draw", -1)
                 print("Cannot declare draw right now.")
                 continue
 
-            col_str = input("Enter column [0-6]: ").strip()
+            if len(command) < 2:
+                print("INVALID INPUT: must be d<col>, p<col>, or draw")
+                continue
+
+            move_type_char = command[0]
+            col_str = command[1:]
+
+            if move_type_char == "d":
+                move_type = "drop"
+            elif move_type_char == "p":
+                move_type = "pop"
+            else:
+                valid = "d<col>, p<col>, or draw" if can_draw else "d<col> or p<col>"
+                print(f"INVALID MOVE TYPE: must be {valid}")
+                continue
 
             if not col_str.isdigit():
                 print("INVALID INPUT: column must be a number")
                 continue
 
             col = int(col_str)
-
-            if move_type not in ("drop", "pop"):
-                valid = "'drop', 'pop', or 'draw'." if can_draw else "'drop' or 'pop'."
-                print(f"INVALID MOVE TYPE: must be {valid}")
-                continue
 
             if (move_type, col) in possible_moves:
                 return move_type, col

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -150,20 +150,13 @@ class TestGamePlay:
 
         moves = iter(
             [
-                "drop",
-                "0",  # P1
-                "drop",
-                "0",  # P2
-                "drop",
-                "1",  # P1
-                "drop",
-                "1",  # P2
-                "drop",
-                "2",  # P1
-                "drop",
-                "2",  # P2
-                "drop",
-                "3",  # P1 wins
+                "d0",  # P1
+                "d0",  # P2
+                "d1",  # P1
+                "d1",  # P2
+                "d2",  # P1
+                "d2",  # P2
+                "d3",  # P1 wins
             ]
         )
         monkeypatch.setattr("builtins.input", lambda _: next(moves))
@@ -186,22 +179,14 @@ class TestGamePlay:
         # loop iteration after the 8th move is recorded.
         moves = iter(
             [
-                "drop",
-                "0",  # P1: col0 has P1 at bottom
-                "drop",
-                "0",  # P2: col0 has P1 at bottom, P2 above
-                "pop",
-                "0",  # P1: removes P1 from bottom; col0 has P2 at bottom
-                "pop",
-                "0",  # P2: removes P2; col0 empty again (2nd occurrence)
-                "drop",
-                "0",  # P1: col0 has P1 at bottom
-                "drop",
-                "0",  # P2: col0 has P1 at bottom, P2 above
-                "pop",
-                "0",  # P1: col0 has P2 at bottom
-                "pop",
-                "0",  # P2: col0 empty again (3rd occurrence -> draw)
+                "d0",  # P1: col0 has P1 at bottom
+                "d0",  # P2: col0 has P1 at bottom, P2 above
+                "p0",  # P1: removes P1 from bottom; col0 has P2 at bottom
+                "p0",  # P2: removes P2; col0 empty again (2nd occurrence)
+                "d0",  # P1: col0 has P1 at bottom
+                "d0",  # P2: col0 has P1 at bottom, P2 above
+                "p0",  # P1: col0 has P2 at bottom
+                "p0",  # P2: col0 empty again (3rd occurrence -> draw)
             ]
         )
         monkeypatch.setattr("builtins.input", lambda _: next(moves))

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -82,7 +82,7 @@ class TestHumanPlayerInitialization:
         player = HumanPlayer(PLAYER1)
         board = Board()
 
-        inputs = iter(["drop", "0"])
+        inputs = iter(["d0"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         move = player.get_move(board)
@@ -93,12 +93,11 @@ class TestHumanPlayerInitialization:
         assert isinstance(move[1], int)
 
     def test_human_player_get_move_invalid_column_then_valid(self, monkeypatch):
-        """Test HumanPlayer.get_move retries when column input
-        is not a number."""
+        """Test HumanPlayer.get_move retries when column input is not a number."""
         player = HumanPlayer(PLAYER1)
         board = Board()
 
-        inputs = iter(["drop", "asdfdf", "drop", "0"])
+        inputs = iter(["dasdfdf", "d0"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         move = player.get_move(board)
@@ -109,7 +108,7 @@ class TestHumanPlayerInitialization:
         player = HumanPlayer(PLAYER1)
         board = Board()
 
-        inputs = iter(["jsdfjdsjf", "0", "drop", "0"])
+        inputs = iter(["j0", "d0"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         move = player.get_move(board)
@@ -124,7 +123,18 @@ class TestHumanPlayerInitialization:
             board, "get_possible_moves", lambda _player_id: [("drop", 0)]
         )
 
-        inputs = iter(["drop", "1", "drop", "0"])
+        inputs = iter(["d1", "d0"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        move = player.get_move(board)
+        assert move == ("drop", 0)
+
+    def test_human_player_get_move_out_of_range_column_then_valid(self, monkeypatch):
+        """Test HumanPlayer.get_move retries when column is out of range."""
+        player = HumanPlayer(PLAYER1)
+        board = Board()
+
+        inputs = iter(["d7", "d0"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         move = player.get_move(board)


### PR DESCRIPTION
## Refactor HumanPlayer input system to single-command format

### What Changed

Simplified the human player move input from a two-step process to a single command format:

**Before:**
```
Enter move type (drop/pop): drop
Enter column [0-6]: 3
```

**After:**
```
Enter move (d<col>/p<col>/draw) [e.g., d3, p6]: d3
```


### Implementation

- **src/game/player.py** (HumanPlayer.get_move): 
  - Parse single command with format `d<column>` for drop or `p<column>` for pop
  - Support `draw` as special case (unchanged)
  - Validate move type character and column number separately
  - Provide clear error messages for invalid formats

- **tests/test_player.py** (HumanPlayerInitialization tests):
  - Updated 4 existing tests to use new command format
  - Added new test: `test_human_player_get_move_out_of_range_column_then_valid`
    - Verifies system rejects out-of-range columns (e.g., "d7" on 7-column board)
    - Confirms retry behavior works correctly

- **tests/test_game.py** (TestGamePlay integration tests):
  - Updated 2 game integration tests to use new format
  - `test_play_player1_wins_horizontal`
  - `test_play_threefold_repetition_draw`

### Why

The new single-command format improves usability:
- Faster input (1 line instead of 2)
- Clearer intent (command and column together)
- Consistent with common game UIs (chess notation, etc.)
- Backward compatible at the API level (get_move still returns (move_type, col))

### Testing

- All 165 tests pass
- New test added for edge case: out-of-range column validation
- Integration tests confirm game flow works end-to-end with new format
- Validation tested: invalid move type, invalid column format, out-of-range, and illegal moves

### Validation

- [x] Tests pass locally (165/165)
- [x] Ruff check passes
- [x] Black format check passes
- [x] New behavior covered by tests (edge cases and integration)

Merging this closes #49 